### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v2.0.0
+              uses: pozil/auto-assign-issue@v2.0.1
               with:
                   assignees: neverased
                   numOfAssignee: 1

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -56,6 +56,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3.27.1
+        uses: github/codeql-action/upload-sarif@v3.28.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -37,7 +37,7 @@ jobs:
         # eslint exits 1 if it finds anything to report
         run: node_modules/.bin/eslint -f node_modules/@microsoft/eslint-formatter-sarif/sarif.js -o results.sarif || true
       # Uploads results.sarif to GitHub repository using the upload-sarif action
-      - uses: github/codeql-action/upload-sarif@v3.27.1
+      - uses: github/codeql-action/upload-sarif@v3.28.0
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.28.0](https://github.com/github/codeql-action/releases/tag/v3.28.0)** on 2024-12-20T18:50:17Z
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v2.0.1](https://github.com/pozil/auto-assign-issue/releases/tag/v2.0.1)** on 2024-11-19T21:25:30Z
