### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v2.0.1
+              uses: pozil/auto-assign-issue@v2.1.2
               with:
                   assignees: neverased
                   numOfAssignee: 1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v2.1.2](https://github.com/pozil/auto-assign-issue/releases/tag/v2.1.2)** on 2025-01-03T09:53:46Z
