### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v2.0.1
+              uses: pozil/auto-assign-issue@v2.1.2
               with:
                   assignees: neverased
                   numOfAssignee: 1

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v4.2.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -56,6 +56,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3.28.0
+        uses: github/codeql-action/upload-sarif@v3.28.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -37,7 +37,7 @@ jobs:
         # eslint exits 1 if it finds anything to report
         run: node_modules/.bin/eslint -f node_modules/@microsoft/eslint-formatter-sarif/sarif.js -o results.sarif || true
       # Uploads results.sarif to GitHub repository using the upload-sarif action
-      - uses: github/codeql-action/upload-sarif@v3.28.0
+      - uses: github/codeql-action/upload-sarif@v3.28.8
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9.0.0
+    - uses: actions/stale@v9.1.0
       with:
         stale-issue-message: 'This issue has become stale and will be closed automatically within a period of time. Sorry about that.'
         stale-pr-message: 'This pull request has become stale and will be closed automatically within a period of time. Sorry about that.'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.28.8](https://github.com/github/codeql-action/releases/tag/v3.28.8)** on 2025-01-29T18:58:48Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.2.0](https://github.com/actions/setup-node/releases/tag/v4.2.0)** on 2025-01-27T03:41:24Z
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v2.1.2](https://github.com/pozil/auto-assign-issue/releases/tag/v2.1.2)** on 2025-01-03T09:53:46Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v9.1.0](https://github.com/actions/stale/releases/tag/v9.1.0)** on 2025-01-21T03:34:36Z
