### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v4.2.2
 
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@master
+        uses: codacy/codacy-analysis-cli-action@v4.4.5
         with:
           output: results.sarif
           format: sarif
@@ -27,6 +27,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@main
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -37,7 +37,7 @@ jobs:
         # eslint exits 1 if it finds anything to report
         run: node_modules/.bin/eslint -f node_modules/@microsoft/eslint-formatter-sarif/sarif.js -o results.sarif || true
       # Uploads results.sarif to GitHub repository using the upload-sarif action
-      - uses: github/codeql-action/upload-sarif@v3.28.10
+      - uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4.2.0
         with:
           token: ${{ secrets.CWB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codacy/codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action)** published a new release **[v4.4.5](https://github.com/codacy/codacy-analysis-cli-action/releases/tag/v4.4.5)** on 2024-07-12T13:51:38Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.28.13](https://github.com/github/codeql-action/releases/tag/v3.28.13)** on 2025-03-24T13:43:47Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[googleapis/release-please-action](https://github.com/googleapis/release-please-action)** published a new release **[v4.2.0](https://github.com/googleapis/release-please-action/releases/tag/v4.2.0)** on 2025-03-07T19:25:46Z
