### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -26,7 +26,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: '22'
           cache: 'pnpm'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.4.0](https://github.com/actions/setup-node/releases/tag/v4.4.0)** on 2025-04-14T02:55:06Z
