### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -37,7 +37,7 @@ jobs:
         # eslint exits 1 if it finds anything to report
         run: node_modules/.bin/eslint -f node_modules/@microsoft/eslint-formatter-sarif/sarif.js -o results.sarif || true
       # Uploads results.sarif to GitHub repository using the upload-sarif action
-      - uses: github/codeql-action/upload-sarif@v3.28.18
+      - uses: github/codeql-action/upload-sarif@v3.28.19
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.28.19](https://github.com/github/codeql-action/releases/tag/v3.28.19)** on 2025-06-03T13:09:00Z
