### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -40,7 +40,7 @@ jobs:
 
             # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
             - name: Run Codacy Analysis CLI
-              uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+              uses: codacy/codacy-analysis-cli-action@v4.4.7
               with:
                   # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
                   # You can also omit the token and run the tools that support default configurations
@@ -56,6 +56,6 @@ jobs:
 
             # Upload the SARIF file generated in the previous step
             - name: Upload SARIF results file
-              uses: github/codeql-action/upload-sarif@v3
+              uses: github/codeql-action/upload-sarif@v3.30.6
               with:
                   sarif_file: results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v3.30.6
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/label-triage.yml
+++ b/.github/workflows/label-triage.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v6.0.1
         with:
           repo-token: '${{ secrets.CWB_TOKEN }}'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v10.1.0
         with:
           stale-issue-message: 'This issue has become stale and will be closed automatically within a period of time. Sorry about that.'
           stale-pr-message: 'This pull request has become stale and will be closed automatically within a period of time. Sorry about that.'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/labeler](https://github.com/actions/labeler)** published a new release **[v6.0.1](https://github.com/actions/labeler/releases/tag/v6.0.1)** on 2025-09-04T17:56:16Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.30.6](https://github.com/github/codeql-action/releases/tag/v3.30.6)** on 2025-10-02T13:53:11Z
* **[codacy/codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action)** published a new release **[v4.4.7](https://github.com/codacy/codacy-analysis-cli-action/releases/tag/v4.4.7)** on 2025-07-17T14:30:19Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v10.1.0](https://github.com/actions/stale/releases/tag/v10.1.0)** on 2025-10-03T19:45:27Z
