### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Create .env file
         run: echo "SECRET=${{ secrets.ENV }}" > .env
@@ -21,12 +21,12 @@ jobs:
         run: echo "${{ secrets.GOOGLE_API }}" > sos-aio-bot-40e1568bd219.json
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@v5.0.0
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.0.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
         steps:
             # Checkout the repository to the GitHub Actions runner
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6.0.2
 
             # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
             - name: Run Codacy Analysis CLI
@@ -56,6 +56,6 @@ jobs:
 
             # Upload the SARIF file generated in the previous step
             - name: Upload SARIF results file
-              uses: github/codeql-action/upload-sarif@v4.31.0
+              uses: github/codeql-action/upload-sarif@v4.35.1
               with:
                   sarif_file: results.sarif

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,5 +8,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Install ESLint
         run: |
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v4.31.0
+        uses: github/codeql-action/upload-sarif@v4.35.1
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/label-feature.yml
+++ b/.github/workflows/label-feature.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close Issue
-        uses: peter-evans/close-issue@v3.0.1
+        uses: peter-evans/close-issue@v3.0.2
         if: contains(github.event.issue.labels.*.name, 'feature')
         with:
           comment: |

--- a/.github/workflows/label-support.yml
+++ b/.github/workflows/label-support.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close Issue
-        uses: peter-evans/close-issue@v3.0.1
+        uses: peter-evans/close-issue@v3.0.2
         if: contains(github.event.issue.labels.*.name, 'support')
         with:
           comment: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v10.1.0
+      - uses: actions/stale@v10.2.0
         with:
           stale-issue-message: 'This issue has become stale and will be closed automatically within a period of time. Sorry about that.'
           stale-pr-message: 'This pull request has become stale and will be closed automatically within a period of time. Sorry about that.'

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.CWB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v5.0.0](https://github.com/pnpm/action-setup/releases/tag/v5.0.0)** on 2026-03-17T12:07:56Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v10.2.0](https://github.com/actions/stale/releases/tag/v10.2.0)** on 2026-02-17T03:03:20Z
* **[peter-evans/close-issue](https://github.com/peter-evans/close-issue)** published a new release **[v3.0.2](https://github.com/peter-evans/close-issue/releases/tag/v3.0.2)** on 2026-03-06T09:24:26Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0)** on 2026-03-04T02:52:09Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.35.1](https://github.com/github/codeql-action/releases/tag/v4.35.1)** on 2026-03-27T16:10:46Z
