### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: 'Auto-assign issue'
         # pozil/auto-assign-issue v3.0.0
-        uses: pozil/auto-assign-issue@70adb98ca8b3941524e9ecde48e89067c4f96736
+        uses: pozil/auto-assign-issue@v3.0.0
         with:
           assignees: neverased
           numOfAssignee: 1

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+        uses: pnpm/action-setup@v6.0.6
         with:
           run_install: false
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
         # codacy/codacy-analysis-cli-action v4.4.7
-        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08
+        uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4.35.3
+        uses: github/codeql-action/upload-sarif@v4.35.4
         with:
           sarif_file: github-code-scanning.sarif

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       # wagoid/commitlint-github-action v6
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+        uses: pnpm/action-setup@v6.0.6
         with:
           run_install: false
 

--- a/.github/workflows/label-feature.yml
+++ b/.github/workflows/label-feature.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Close Issue
         # peter-evans/close-issue v3.0.2
-        uses: peter-evans/close-issue@05dff7ca07116e5707cfb3a3cd4af7bb5e43524c
+        uses: peter-evans/close-issue@v3.0.2
         if: contains(github.event.issue.labels.*.name, 'feature')
         with:
           comment: |

--- a/.github/workflows/label-support.yml
+++ b/.github/workflows/label-support.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Close Issue
         # peter-evans/close-issue v3.0.2
-        uses: peter-evans/close-issue@05dff7ca07116e5707cfb3a3cd4af7bb5e43524c
+        uses: peter-evans/close-issue@v3.0.2
         if: contains(github.event.issue.labels.*.name, 'support')
         with:
           comment: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Release Please
         # googleapis/release-please-action v5
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
+        uses: googleapis/release-please-action@v5.0.0
         with:
           token: ${{ secrets.CWB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.CWB_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
         # saadmk11/github-actions-version-updater v0.9.0
-        uses: saadmk11/github-actions-version-updater@d8781caf11d11168579c8e5e94f62b068038f442
+        uses: saadmk11/github-actions-version-updater@v0.9.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.CWB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[googleapis/release-please-action](https://github.com/googleapis/release-please-action)** published a new release **[v5.0.0](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0)** on 2026-04-22T18:03:34Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.35.4](https://github.com/github/codeql-action/releases/tag/v4.35.4)** on 2026-05-07T15:54:03Z
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v3.0.0](https://github.com/pozil/auto-assign-issue/releases/tag/v3.0.0)** on 2026-04-24T08:48:59Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.9.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.9.0)** on 2025-07-15T09:42:28Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v6.0.6](https://github.com/pnpm/action-setup/releases/tag/v6.0.6)** on 2026-05-08T23:57:14Z
* **[peter-evans/close-issue](https://github.com/peter-evans/close-issue)** published a new release **[v3.0.2](https://github.com/peter-evans/close-issue/releases/tag/v3.0.2)** on 2026-03-06T09:24:26Z
* **[codacy/codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action)** published a new release **[v4.4.7](https://github.com/codacy/codacy-analysis-cli-action/releases/tag/v4.4.7)** on 2025-07-17T14:30:19Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
