### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@v6.0.6
+        uses: pnpm/action-setup@v6.0.8
         with:
           run_install: false
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4.35.4
+        uses: github/codeql-action/upload-sarif@v4.35.5
         with:
           sarif_file: github-code-scanning.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@v6.0.6
+        uses: pnpm/action-setup@v6.0.8
         with:
           run_install: false
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v6.0.8](https://github.com/pnpm/action-setup/releases/tag/v6.0.8)** on 2026-05-12T12:37:50Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.35.5](https://github.com/github/codeql-action/releases/tag/v4.35.5)** on 2026-05-15T11:24:04Z
