### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: 'Auto-assign issue'
         # pozil/auto-assign-issue v3.0.0
-        uses: pozil/auto-assign-issue@v4.0.0
+        uses: pozil/auto-assign-issue@v4.0.1
         with:
           assignees: neverased
           numOfAssignee: 1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v4.0.1](https://github.com/pozil/auto-assign-issue/releases/tag/v4.0.1)** on 2026-06-11T13:40:39Z
