### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: 'Auto-assign issue'
         # pozil/auto-assign-issue v3.0.0
-        uses: pozil/auto-assign-issue@v4.0.0
+        uses: pozil/auto-assign-issue@v4.0.1
         with:
           assignees: neverased
           numOfAssignee: 1

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.1
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '26.3.0'
           cache: 'pnpm'

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.1
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4.36.2
+        uses: github/codeql-action/upload-sarif@v4.37.4
         with:
           sarif_file: github-code-scanning.sarif

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.1
       # wagoid/commitlint-github-action v6
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7.0.1
 
       - name: Install pnpm
         # pnpm/action-setup v6.0.5
-        uses: pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@v6.0.9
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '26.3.0'
           cache: 'pnpm'

--- a/.github/workflows/label-triage.yml
+++ b/.github/workflows/label-triage.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6.1.0
+      - uses: actions/labeler@v7.0.0
         with:
           repo-token: '${{ secrets.CWB_TOKEN }}'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v10.3.0
+      - uses: actions/stale@v11.0.0
         with:
           stale-issue-message: 'This issue has become stale and will be closed automatically within a period of time. Sorry about that.'
           stale-pr-message: 'This pull request has become stale and will be closed automatically within a period of time. Sorry about that.'

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.CWB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v6.0.9](https://github.com/pnpm/action-setup/releases/tag/v6.0.9)** on 2026-06-15T12:06:03Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)** on 2026-07-20T15:10:05Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v11.0.0](https://github.com/actions/stale/releases/tag/v11.0.0)** on 2026-07-28T02:44:32Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v7.0.0](https://github.com/actions/setup-node/releases/tag/v7.0.0)** on 2026-07-14T02:46:05Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v4.37.4](https://github.com/github/codeql-action/releases/tag/v4.37.4)** on 2026-07-30T09:21:20Z
* **[actions/labeler](https://github.com/actions/labeler)** published a new release **[v7.0.0](https://github.com/actions/labeler/releases/tag/v7.0.0)** on 2026-07-21T02:40:50Z
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v4.0.1](https://github.com/pozil/auto-assign-issue/releases/tag/v4.0.1)** on 2026-06-11T13:40:39Z
